### PR TITLE
Shot import issue: extraction time calc and missing negative numbered grinder setting

### DIFF
--- a/SDB.tcl
+++ b/SDB.tcl
@@ -1154,8 +1154,12 @@ proc ::plugins::SDB::load_shot { filename {read_series 1} {read_description 1} {
 	
 	if { [string is true $read_description] } {	
 		foreach field_name [concat grinder_setting [metadata fields -domain shot -category description -data_type {number boolean}]] {
-			if { [info exists file_sets($field_name)]  && $file_sets($field_name) > 0 } {
-				set shot_data($field_name) $file_sets($field_name)
+			if { [info exists file_sets($field_name)] } {
+				# grinder_setting is a string
+				# other fields are numbers and must be non-zero & positive
+				if { $field_name == "grinder_setting" || $file_sets($field_name) > 0 } {
+					set shot_data($field_name) $file_sets($field_name)
+				}
 			} else {
 				# We use {} instead of 0 to get DB NULLs and empty values in entry textboxes
 				set shot_data($field_name) {}

--- a/SDB.tcl
+++ b/SDB.tcl
@@ -1135,7 +1135,7 @@ proc ::plugins::SDB::load_shot { filename {read_series 1} {read_description 1} {
 		lappend text_fields profile_title skin beverage_type
 		# We need to treat grinder_setting differently because it's declared as a category, but treated as number by some skins
 		# (with empty=zero)
-		
+
 		set idx [lsearch -exact $text_fields grinder_setting]
 		if { $idx > -1 } {
 			set text_fields [lreplace $text_fields $idx $idx]
@@ -1154,12 +1154,10 @@ proc ::plugins::SDB::load_shot { filename {read_series 1} {read_description 1} {
 	
 	if { [string is true $read_description] } {	
 		foreach field_name [concat grinder_setting [metadata fields -domain shot -category description -data_type {number boolean}]] {
-			if { [info exists file_sets($field_name)] } {
-				# grinder_setting is a string
-				# other fields are numbers and must be non-zero & positive
-				if { $field_name == "grinder_setting" || $file_sets($field_name) > 0 } {
-					set shot_data($field_name) $file_sets($field_name)
-				}
+			# grinder_setting is a string
+			# other fields are numbers and must be non-zero & positive
+			if { [info exists file_sets($field_name)] && ($field_name == "grinder_setting" || $file_sets($field_name) > 0) } {
+				set shot_data($field_name) $file_sets($field_name)
 			} else {
 				# We use {} instead of 0 to get DB NULLs and empty values in entry textboxes
 				set shot_data($field_name) {}


### PR DESCRIPTION
Extraction time calc for godshot enabled shots:
- ~~Moved series reading part to in front of the time calculation code so other named series are available to determine the minimum siries length~~
- Applied trimming code to time series (x-axis)

Missing import for negative numbered grinder setting:
- Treat `grinder_setting` as a special case (without numeric comparison)
- This fixed the issue that the grinder setting textbox losing its value