### PR TITLE
save modified espresso data to v2 snap-shot too

### DIFF
--- a/SDB.tcl
+++ b/SDB.tcl
@@ -1366,6 +1366,8 @@ proc ::plugins::SDB::modify_shot_file { path arr_new_settings { backup_file {} }
 	}
 	if { $write_file == 1 } {
 		write_file $path $espresso_data
+        set fbasename [file rootname [file tail $path]]
+        shot::convert_legacy_to_v2 $path "[homedir]/history_v2" "${fbasename}.json" 0
 		msg "Updated past espresso history file $path"
 	}
 	


### PR DESCRIPTION
Whenever a previous shot is updated (e.g. in DYE) - the shot is saved, but only in DB and v1 shot file. 
This pr saves the shot in v2 json profile as well - which will help [advanced_rest_api](https://github.com/randomcoffeesnob/decent-advanced-rest-api) to display shot notes as well.